### PR TITLE
chore: bump pnpm version to 9.14.4 and use pnpm dlx instead of pnpx

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "keywords": ["color", "palette", "canvas", "image", "imagedata", "jpg", "png"],
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
+    "preinstall": "pnpm dlx only-allow pnpm",
     "prepare": "husky install",
     "prebuild": "pnpm clean",
     "build": "tsc && vite build",
@@ -52,8 +52,8 @@
     "test:e2e:install": "pnpm dlx playwright install chromium --with-deps",
     "test:bench": "vitest bench --run",
     "test:ui": "vitest run --coverage --ui",
-    "release": "pnpx semantic-release",
-    "release:check": "pnpx semantic-release --dry-run --no-ci"
+    "release": "pnpm dlx semantic-release",
+    "release:check": "pnpm dlx semantic-release --dry-run --no-ci"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
@@ -91,5 +91,5 @@
     "*.{js,ts}": ["pnpm run lint:biome:fix", "pnpm run format"],
     "*.{json,yml,md}": ["pnpm run format"]
   },
-  "packageManager": "pnpm@8.15.4"
+  "packageManager": "pnpm@9.14.4"
 }


### PR DESCRIPTION
## Description

This PR updates the `packageManager` version to the [latest (9.14.4)](https://github.com/pnpm/pnpm/releases/tag/v9.14.4) and replaces `pnpx` with `pnpm dlx` in the `package.json` file.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation updates
- [ ] Other: <!-- Please describe -->

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] My changes follow the project's coding style.
- [x] My changes generate no new warnings or errors.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.