### PR TITLE
chore: modify release workflow to install Playwright before running e2e tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Check the syntax of the code
         run: pnpm run lint
 
-      - name: Run the unit
-        run: pnpm run test
+      - name: Run the unit and e2e tests
+        run: pnpm run test:e2e:install && pnpm run test
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This PR modifies the release workflow to install Playwright before running end-to-end (e2e) tests.  
The `pnpm run test:e2e:install script` has been added to ensure Playwright is installed during the test execution step.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation updates
- [ ] Other: <!-- Please describe -->

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] My changes follow the project's coding style.
- [x] My changes generate no new warnings or errors.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.