### PR TITLE
feat: implement Weighted Farthest Point Sampling for prominent color sampling

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2659,7 +2659,6 @@ packages:
   read-pkg-up@11.0.0:
     resolution: {integrity: sha512-LOVbvF1Q0SZdjClSefZ0Nz5z8u+tIE7mV5NibzmE9VYmDe9CaBbAVtz1veOSZbofrdsilxuDAYnFenukZVp8/Q==}
     engines: {node: '>=18'}
-    deprecated: Renamed to read-package-up
 
   read-pkg@9.0.1:
     resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}

--- a/src/math/sampling/index.ts
+++ b/src/math/sampling/index.ts
@@ -1,3 +1,4 @@
 export { FarthestPointSampling } from './fps';
 export { RandomSampling } from './random';
 export type { SamplingStrategy } from './strategy';
+export { WeightedFarthestPointSampling } from './wfps';

--- a/src/math/sampling/random.ts
+++ b/src/math/sampling/random.ts
@@ -12,17 +12,20 @@ export class RandomSampling<P extends Point> implements SamplingStrategy<P> {
   /**
    * {@inheritDoc SamplingStrategy.sample}
    */
-  sample(points: P[], n: number): P[] {
+  sample(points: P[], n: number): Set<number> {
     assert(n > 0, `The number of data points to downsample(${n}) must be greater than 0`);
     if (n >= points.length) {
-      return [...points];
+      return new Set(points.keys());
     }
 
-    const sampled = new Set<P>();
+    const sampled = new Set<number>();
     while (sampled.size < n) {
       const index = Math.floor(Math.random() * points.length);
-      sampled.add(points[index]);
+      if (sampled.has(index)) {
+        continue;
+      }
+      sampled.add(index);
     }
-    return Array.from(sampled);
+    return sampled;
   }
 }

--- a/src/math/sampling/strategy.ts
+++ b/src/math/sampling/strategy.ts
@@ -7,12 +7,12 @@ import type { Point } from '../point';
  */
 export interface SamplingStrategy<P extends Point> {
   /**
-   * Downsample the data points according to the strategy.
+   * Sample the data points with the given number of data points.
    *
-   * @param points - The set of data points to downsample.
-   * @param n - The number of data points to downsample.
-   * @returns The downsampled data points.
+   * @param points - The data points to sample.
+   * @param n - The number of data points to sample.
+   * @returns The indices of the sampled data points.
    * @throws {RangeError} If the `n` is less than or equal to 0.
    */
-  sample(points: P[], n: number): P[];
+  sample(points: P[], n: number): Set<number>;
 }

--- a/src/math/sampling/wfps.ts
+++ b/src/math/sampling/wfps.ts
@@ -1,0 +1,57 @@
+import { assert } from '../../utils';
+import type { DistanceMeasure } from '../distance';
+import type { Point } from '../point';
+import { FarthestPointSampling } from './fps';
+
+/**
+ * WeightedFarthestPointSampling class represents a strategy for sampling a set of data points by selecting the farthest data points from the sampled data points with weights.
+ *
+ * @typeParam P - The type of the point.
+ * @see {@link FarthestPointSampling}
+ */
+export class WeightedFarthestPointSampling<P extends Point> extends FarthestPointSampling<P> {
+  /**
+   * Create a new WeightedFarthestPointSampling instance.
+   *
+   * @param weights - The weights of the data points.
+   * @param distanceMeasure - The distance measure to measure the distance between two points.
+   */
+  constructor(
+    private readonly weights: number[],
+    distanceMeasure: DistanceMeasure,
+  ) {
+    super(distanceMeasure);
+  }
+
+  /**
+   * {@inheritDoc SamplingStrategy.sample}
+   */
+  sample(points: P[], n: number): Set<number> {
+    assert(n > 0, `The number of data points to downsample(${n}) must be greater than 0`);
+    assert(points.length === this.weights.length, 'The number of data points and weights must be the same.');
+    return super.sample(points, n);
+  }
+
+  /**
+   * {@inheritDoc FarthestPointSampling.distance}
+   */
+  protected distance(points: P[], i: number, j: number): number {
+    return super.distance(points, i, j) * this.weights[j];
+  }
+
+  /**
+   * {@inheritDoc FarthestPointSampling.findInitialIndex}
+   */
+  protected findInitialIndex(): number {
+    let maxWeight = 0;
+    let initialIndex = -1;
+    for (let i = 0; i < this.weights.length; i++) {
+      const weight = this.weights[i];
+      if (weight > maxWeight) {
+        maxWeight = weight;
+        initialIndex = i;
+      }
+    }
+    return initialIndex;
+  }
+}

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -153,12 +153,15 @@ export class Palette {
 
     const neighborSearch = KDTreeSearch.build(colors, 4, euclidean);
     const coefficients = new Array<number>(colors.length).fill(MAX_SCORE_COEFFICIENT);
-    const sampledColors = this.samplingStrategy.sample(colors, n);
-    return sampledColors.map((color: Point3): NamedSwatch => {
+    const sampledIndices = this.samplingStrategy.sample(colors, n);
+    const swatches: NamedSwatch[] = [];
+    for (const index of sampledIndices) {
+      const color = colors[index];
       const swatch = Palette.findOptimalSwatch(candidates, color, neighborSearch, coefficients, themeStrategy);
       const name = Palette.findColorName(swatch.color);
-      return { name, ...swatch };
-    });
+      swatches.push({ name, ...swatch });
+    }
+    return swatches;
   }
 
   private createThemeStrategy(theme: Theme): ThemeStrategy {

--- a/test/math/sampling/fps.test.ts
+++ b/test/math/sampling/fps.test.ts
@@ -8,7 +8,7 @@ const points: Point2[] = [
   [0.0, 1.0],
   [1.0, 1.0],
   [2.0, 2.0],
-];
+] as const;
 
 describe('FarthestPointSampling', () => {
   describe('constructor', () => {
@@ -28,11 +28,7 @@ describe('FarthestPointSampling', () => {
       const actual = sampling.sample(points, 2);
 
       // Assert
-      expect(actual).toHaveLength(2);
-      expect(actual).toContainAllValues([
-        [0.0, 0.0],
-        [2.0, 2.0],
-      ]);
+      expect(actual).toMatchObject(new Set([0, 4]));
     });
 
     it('should return all data points when n is greater than or equal to the number of data points', () => {
@@ -41,8 +37,7 @@ describe('FarthestPointSampling', () => {
       const actual = sampling.sample(points, 5);
 
       // Assert
-      expect(actual).toHaveLength(5);
-      expect(actual).toContainAllValues(points);
+      expect(actual).toMatchObject(new Set([0, 1, 2, 3, 4]));
     });
 
     it('should throw an AssertionError when n is less than or equal to 0', () => {

--- a/test/math/sampling/random.test.ts
+++ b/test/math/sampling/random.test.ts
@@ -28,8 +28,7 @@ describe('RandomSampling', () => {
       const actual = sampling.sample(points, 3);
 
       // Assert
-      expect(actual.length).toEqual(3);
-      expect(actual).toContainAnyValues(points);
+      expect(actual.size).toEqual(3);
     });
 
     it('should return all data points when n is greater than or equal to the number of data points', () => {
@@ -38,8 +37,8 @@ describe('RandomSampling', () => {
       const actual = sampling.sample(points, 5);
 
       // Assert
-      expect(actual.length).toEqual(5);
-      expect(actual).toContainAllValues(points);
+      expect(actual.size).toEqual(5);
+      expect(actual).toMatchObject(new Set([0, 1, 2, 3, 4]));
     });
 
     it('should throw an AssertionError when n is less than or equal to 0', () => {

--- a/test/math/sampling/wfps.test.ts
+++ b/test/math/sampling/wfps.test.ts
@@ -1,0 +1,76 @@
+import { type Point2, WeightedFarthestPointSampling, euclidean } from '@internal/math';
+import { AssertionError } from '@internal/utils';
+import { describe, expect, it } from 'vitest';
+
+const points: Point2[] = [
+  [0.0, 0.0],
+  [1.0, 1.0],
+  [1.0, 2.0],
+  [2.0, 2.0],
+  [2.0, 4.0],
+  [3.0, 5.0],
+  [1.0, 0.0],
+  [0.0, 1.0],
+  [0.0, 2.0],
+] as const;
+
+const weights: number[] = [1.0, 1.0, 2.0, 3.0, 5.0, 8.0, 13.0, 21.0, 34.0] as const;
+
+describe('WeightedFarthestPointSampling', () => {
+  it('should create a new instance', () => {
+    // Act
+    const actual = new WeightedFarthestPointSampling<Point2>(weights, euclidean);
+
+    // Assert
+    expect(actual).toBeDefined();
+  });
+
+  describe('sample', () => {
+    it('should return n data points', () => {
+      // Act
+      const sampling = new WeightedFarthestPointSampling<Point2>(weights, euclidean);
+      const actual = sampling.sample(points, 3);
+
+      // Assert
+      expect(actual).toMatchObject(new Set([5, 6, 8]));
+    });
+
+    it('should return all data points when n is greater than or equal to the number of data points', () => {
+      // Act
+      const sampling = new WeightedFarthestPointSampling<Point2>(weights, euclidean);
+      const actual = sampling.sample(points, 9);
+
+      // Assert
+      expect(actual).toMatchObject(new Set([0, 1, 2, 3, 4, 5, 6, 7, 8]));
+    });
+
+    it('should throw an AssertionError when n is less than or equal to 0', () => {
+      // Arrange
+      const sampling = new WeightedFarthestPointSampling<Point2>(weights, euclidean);
+
+      // Assert
+      expect(() => {
+        // Act
+        sampling.sample(points, 0);
+      }).toThrowError(AssertionError);
+    });
+
+    it('should throw an AssertionError when the number of data points and weights are different', () => {
+      // Arrange
+      const sampling = new WeightedFarthestPointSampling<Point2>(weights, euclidean);
+
+      // Assert
+      expect(() => {
+        // Act
+        sampling.sample(
+          [
+            [0.5, 1.0],
+            [3.0, 2.5],
+            [1.0, 1.0],
+          ],
+          2,
+        );
+      }).toThrowError(AssertionError);
+    });
+  });
+});


### PR DESCRIPTION
## Description

In this Pull Request, the Weighted Farthest Point Sampling algorithm was implemented for prominent color sampling. Additionally, the `SamplingStrategy.sample` method was updated to return indices only.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation updates
- [ ] Other: <!-- Please describe -->

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] My changes follow the project's coding style.
- [x] My changes generate no new warnings or errors.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.